### PR TITLE
Address `circomspect` warnings

### DIFF
--- a/packages/utils/src/float.circom
+++ b/packages/utils/src/float.circom
@@ -8,6 +8,9 @@ include "mux1.circom";
 template MSB(n) {
     signal input in;
     signal output out;
+   
+    // Ensure the input is less than 2^254 within the finite field for BN254.
+    assert(in < (2 ** 254));
 
     // Convert the number to its bit representation.
     var n2b[n];

--- a/packages/utils/src/safe-comparators.circom
+++ b/packages/utils/src/safe-comparators.circom
@@ -11,17 +11,9 @@ template SafeLessThan(n) {
     signal input in[2];
     signal output out;
 
-    // Convert both inputs to their bit representations to ensure
-    // they fit within 'n' bits.
-    var n2b1[n];
-    n2b1 = Num2Bits(n)(in[0]);
-
-    var n2b2[n];
-    n2b2 = Num2Bits(n)(in[1]);
-
     // Additional conversion to handle arithmetic operation and capture the comparison result.
-    var n2b[n+1];
-    n2b = Num2Bits(n + 1)(in[0] + (1<<n) - in[1]);
+    var n2b[254];
+    n2b = Num2Bits_strict()(in[0] + (1<<n) - in[1]);
 
     // Determine if in[0] is less than in[1] based on the most significant bit.
     out <== 1 - n2b[n];


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
This PR addresses the `circomspect` warnings for the `poseidon-cipher`, `poseidon-proof`, `utils(float, safe-comparators)` packages.
 
<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->
There are still some warnings but we can safely ignore them:
- `poseidon-cipher`: 
  - __warning: The output signal `decryptedLast` defined by the template `PoseidonDecryptIterations` is not constrained in `PoseidonDecryptWithoutCheck`__: yes, that's why is called `PoseidonDecryptWITHOUTCHECK` because there's no checks there.
  - __warning: Inputs to `LessThan` need to be constrained to ensure that they are non-negative__: added an assert to avoid potentially unsecure negative inputs to LessThan.
- `float`: __warning: Using `Num2Bits` to convert field elements to bits may lead to aliasing issues.__: added an assert to check that the input is always under the BN254 curve. May @sripwoud or @cedoor or @ctrlc03 can countercheck this? 

## Related Issue(s)
PR #7
<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information
none
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn compile` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes
