### PR TITLE
feat: better `IntegerDivision`implementation

### DIFF
--- a/packages/utils/circuits.json
+++ b/packages/utils/circuits.json
@@ -12,7 +12,7 @@
     "integer-division": {
         "file": "float",
         "template": "IntegerDivision",
-        "params": [252]
+        "params": []
     },
     "to-float": {
         "file": "float",
@@ -22,22 +22,22 @@
     "division-from-float": {
         "file": "float",
         "template": "DivisionFromFloat",
-        "params": [74, 251]
+        "params": [74]
     },
     "division-from-normal": {
         "file": "float",
         "template": "DivisionFromNormal",
-        "params": [74, 251]
+        "params": [74]
     },
     "multiplication-from-float": {
         "file": "float",
         "template": "MultiplicationFromFloat",
-        "params": [74, 251]
+        "params": [74]
     },
     "multiplication-from-normal": {
         "file": "float",
         "template": "MultiplicationFromNormal",
-        "params": [74, 251]
+        "params": [74]
     },
     "safe-less-than": {
         "file": "safe-comparators",

--- a/packages/utils/src/float.circom
+++ b/packages/utils/src/float.circom
@@ -51,6 +51,7 @@ template IntegerDivision() {
     signal output quotient;
     signal output remainder;
     
+    assert(divisor != 0);
     quotient <-- dividend \ divisor;
     remainder <-- dividend % divisor;
     
@@ -144,6 +145,14 @@ template MultiplicationFromFloat(W) {
     assert(lta == 1);
     assert(ltb == 1);
 
+    // Add validation for negative numbers
+    signal isANonNegative <== SafeGreaterEqThan(252)([a, 0]);
+    signal isBNonNegative <== SafeGreaterEqThan(252)([b, 0]);
+    
+    // Assert both inputs are non-negative
+    1 === isANonNegative;
+    1 === isBNonNegative;
+
     // Perform integer division after multiplication to adjust the result back to W decimal digits.
     signal quotient;
     (quotient, _) <== IntegerDivision()(a * b, 10 ** W);
@@ -158,6 +167,14 @@ template MultiplicationFromNormal(W) {
     signal input b;
     // Product.
     signal output c;
+
+    // Add validation for negative numbers
+    signal isANonNegative <== SafeGreaterEqThan(252)([a, 0]);
+    signal isBNonNegative <== SafeGreaterEqThan(252)([b, 0]);
+    
+    // Assert both inputs are non-negative
+    1 === isANonNegative;
+    1 === isBNonNegative;
 
     // Convert input to float and perform multiplication.
     c <== MultiplicationFromFloat(W)(ToFloat(W)(a), ToFloat(W)(b));

--- a/packages/utils/tests/float.test.ts
+++ b/packages/utils/tests/float.test.ts
@@ -78,45 +78,43 @@ describe("float", () => {
     })
 
     describe("IntegerDivision", () => {
-        let circuit: WitnessTester<["a", "b"], ["c"]>
+        let circuit: WitnessTester<["dividend", "divisor"], ["quotient", "remainder"]>
 
         it("Should throw when trying to perform division per zero [x, 0]", async () => {
-            // Test values
             const inValues = {
                 a: 10,
                 b: 0
             }
 
             const INPUT = {
-                a: inValues.a,
-                b: inValues.b
+                dividend: inValues.a,
+                divisor: inValues.b
             }
 
             circuit = await circomkit.WitnessTester("IntegerDivision", {
                 file: "float",
                 template: "IntegerDivision",
-                params: [2] // Assuming we're working within 2-bit numbers.
+                params: []
             })
 
             await circuit.expectFail(INPUT)
         })
 
         it("Should throw when trying to perform division per negative number [x, -x]", async () => {
-            // Test values
             const inValues = {
                 a: 10,
                 b: -10
             }
 
             const INPUT = {
-                a: inValues.a,
-                b: inValues.b
+                dividend: inValues.a,
+                divisor: inValues.b
             }
 
             circuit = await circomkit.WitnessTester("IntegerDivision", {
                 file: "float",
                 template: "IntegerDivision",
-                params: [2] // Assuming we're working within 2-bit numbers.
+                params: []
             })
 
             await circuit.expectFail(INPUT)
@@ -128,21 +126,26 @@ describe("float", () => {
                 a: 0,
                 b: 1
             }
-            const expectedOut = 0
+
+            const expectedOut = {
+                quotient: 0,
+                remainder: 0
+            }
 
             const INPUT = {
-                a: inValues.a,
-                b: inValues.b
+                dividend: inValues.a,
+                divisor: inValues.b
             }
 
             const OUTPUT = {
-                c: expectedOut
+                quotient: expectedOut.quotient,
+                remainder: expectedOut.remainder
             }
 
             circuit = await circomkit.WitnessTester("IntegerDivision", {
                 file: "float",
                 template: "IntegerDivision",
-                params: [2] // Assuming we're working within 2-bit numbers.
+                params: []
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -154,21 +157,25 @@ describe("float", () => {
                 a: 10,
                 b: 2
             }
-            const expectedOut = 5
+            const expectedOut = {
+                quotient: 5,
+                remainder: 0
+            }
 
             const INPUT = {
-                a: inValues.a,
-                b: inValues.b
+                dividend: inValues.a,
+                divisor: inValues.b
             }
 
             const OUTPUT = {
-                c: expectedOut
+                quotient: expectedOut.quotient,
+                remainder: expectedOut.remainder
             }
 
             circuit = await circomkit.WitnessTester("IntegerDivision", {
                 file: "float",
                 template: "IntegerDivision",
-                params: [10] // Assuming we're working within 10-bit numbers.
+                params: []
             })
             await circuit.expectPass(INPUT, OUTPUT)
         })
@@ -220,7 +227,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromFloat", {
                 file: "float",
                 template: "DivisionFromFloat",
-                params: [2, 1] // W decimal digits, N Assuming we're working within 2-bit numbers.
+                params: [1] // W decimal digits
             })
 
             await circuit.expectFail(INPUT)
@@ -241,7 +248,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromFloat", {
                 file: "float",
                 template: "DivisionFromFloat",
-                params: [2, 1] // W decimal digits, N Assuming we're working within 2-bit numbers.
+                params: [1] // W decimal digits
             })
 
             await circuit.expectFail(INPUT)
@@ -267,7 +274,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromFloat", {
                 file: "float",
                 template: "DivisionFromFloat",
-                params: [2, 1] // W decimal digits, N Assuming we're working within 2-bit numbers.
+                params: [1] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -293,7 +300,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromFloat", {
                 file: "float",
                 template: "DivisionFromFloat",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -318,7 +325,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromNormal", {
                 file: "float",
                 template: "DivisionFromNormal",
-                params: [2, 1] // W decimal digits, N Assuming we're working within 2-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectFail(INPUT)
@@ -339,7 +346,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromNormal", {
                 file: "float",
                 template: "DivisionFromNormal",
-                params: [2, 1] // W decimal digits, N Assuming we're working within 2-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectFail(INPUT)
@@ -365,7 +372,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromNormal", {
                 file: "float",
                 template: "DivisionFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -391,7 +398,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("DivisionFromNormal", {
                 file: "float",
                 template: "DivisionFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -416,7 +423,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromFloat", {
                 file: "float",
                 template: "MultiplicationFromFloat",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectFail(INPUT)
@@ -442,7 +449,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromFloat", {
                 file: "float",
                 template: "MultiplicationFromFloat",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -468,7 +475,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromFloat", {
                 file: "float",
                 template: "MultiplicationFromFloat",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -494,7 +501,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromFloat", {
                 file: "float",
                 template: "MultiplicationFromFloat",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -520,7 +527,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromFloat", {
                 file: "float",
                 template: "MultiplicationFromFloat",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -545,7 +552,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromNormal", {
                 file: "float",
                 template: "MultiplicationFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectFail(INPUT)
@@ -571,7 +578,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromNormal", {
                 file: "float",
                 template: "MultiplicationFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -597,7 +604,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromNormal", {
                 file: "float",
                 template: "MultiplicationFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -623,7 +630,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromNormal", {
                 file: "float",
                 template: "MultiplicationFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)
@@ -649,7 +656,7 @@ describe("float", () => {
             circuit = await circomkit.WitnessTester("MultiplicationFromNormal", {
                 file: "float",
                 template: "MultiplicationFromNormal",
-                params: [2, 31] // W decimal digits, N Assuming we're working within 32-bit numbers.
+                params: [2] // W decimal digits
             })
 
             await circuit.expectPass(INPUT, OUTPUT)


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

This PR introduces a better `IntegerDivison`template
There are none breaking changes. 

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #14 


## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] My code follows the style guidelines of this project
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [x] I have run `yarn format` and `yarn compile` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

It generates new warnings:
```
circomspect: analyzing template 'MultiplicationFromFloat'
warning: The output signal `remainder` defined by the template `IntegerDivision` is not constrained in `MultiplicationFromFloat`.
    ┌─ /Users/peterpan/rd/p/zk-kit.circom/packages/utils/src/float.circom:158:23
    │
158 │     (quotient, _) <== IntegerDivision()(a * b, 10 ** W);
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The template `IntegerDivision` is instantiated here.
    │
    = For more details, see https://github.com/trailofbits/circomspect/blob/main/doc/analysis_passes.md#unused-output-signal.

warning: Using the signal assignment operator `<--` does not constrain the assigned signal.
   ┌─ /Users/peterpan/rd/p/zk-kit.circom/packages/utils/src/float.circom:55:5
   │
55 │     quotient <-- dividend \ divisor;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The assigned signal `quotient` is not constrained here.
   ·
63 │     dividend === divisor * quotient + remainder;
   │     -------------------------------------------- The signal `quotient` is constrained here.
   │
   = For more details, see https://github.com/trailofbits/circomspect/blob/main/doc/analysis_passes.md#signal-assignment.


circomspect: analyzing template 'IntegerDivision'
warning: Using the signal assignment operator `<--` does not constrain the assigned signal.
   ┌─ /Users/peterpan/rd/p/zk-kit.circom/packages/utils/src/float.circom:56:5
   │
56 │     remainder <-- dividend % divisor;
   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The assigned signal `remainder` is not constrained here.
   ·
59 │     signal isLessThan <== SafeLessThan(252)([remainder, divisor]);
   │                           --------------------------------------- The signal `remainder` is constrained here.
   ·
63 │     dividend === divisor * quotient + remainder;
   │     -------------------------------------------- The signal `remainder` is constrained here.
   │
   = For more details, see https://github.com/trailofbits/circomspect/blob/main/doc/analysis_passes.md#signal-assignment.

circomspect: analyzing template 'DivisionFromFloat'
warning: The output signal `remainder` defined by the template `IntegerDivision` is not constrained in `DivisionFromFloat`.
    ┌─ /Users/peterpan/rd/p/zk-kit.circom/packages/utils/src/float.circom:107:23
    │
107 │     (quotient, _) <== IntegerDivision()(a * (10 ** W), b);
    │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The template `IntegerDivision` is instantiated here.
    │
    = For more details, see https://github.com/trailofbits/circomspect/blob/main/doc/analysis_passes.md#unused-output-signal.
```