### PR TITLE
refactor(poseidon-cipher): simplify nonce validation using Num2Bits

### DIFF
--- a/packages/poseidon-cipher/src/poseidon-cipher.circom
+++ b/packages/poseidon-cipher/src/poseidon-cipher.circom
@@ -11,6 +11,7 @@ include "poseidon-constants-old.circom";
 // we import this for util functions like Ark, Mix, Sigma
 include "poseidon_old.circom";
 include "comparators.circom";
+include "bitify.circom";
 
 // Poseidon decryption circuit
 // param length: length of the input
@@ -107,13 +108,9 @@ template PoseidonDecryptIterations(length) {
     signal output decrypted[decryptedLength];
     signal output decryptedLast;
 
-    var two128 = 2 ** 128;
-
     // nonce must be < 2^128
-    component lt = LessThan(252);
-    lt.in[0] <== nonce;
-    lt.in[1] <== two128;
-    lt.out === 1;
+    component n2b = Num2Bits(128);
+    n2b.in <== nonce;
 
     // calculate the number of iterations
     // needed for the decryption
@@ -133,7 +130,7 @@ template PoseidonDecryptIterations(length) {
     strategies[0].inputs[0] <== 0;
     strategies[0].inputs[1] <== key[0];
     strategies[0].inputs[2] <== key[1];
-    strategies[0].inputs[3] <== nonce + (length * two128);
+    strategies[0].inputs[3] <== nonce + (length << 128);
 
     // loop for n iterations
     for (var i = 0; i < n; i++) {


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

- Removed the explicit two128 variable declaration (`var two128 = 2 ** 128`)
- Replaced the nonce validation using `LessThan` component with a simpler `Num2Bits(128)(nonce)` check
- Changed `length * two128` to `length << 128` in the initial state calculation for better consistency with bit operations

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

Fixes #16 

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
