### PR TITLE
fix(utils/safe-comparators): constrain inputs to n bits

### DIFF
--- a/packages/utils/src/safe-comparators.circom
+++ b/packages/utils/src/safe-comparators.circom
@@ -11,12 +11,19 @@ template SafeLessThan(n) {
     signal input in[2];
     signal output out;
 
+    // Constrain inputs to n bits
+    component range_check[2];
+    for (var i = 0; i < 2; i++) {
+        range_check[i] = Num2Bits(n);
+        range_check[i].in <== in[i];
+    }
+
     // Additional conversion to handle arithmetic operation and capture the comparison result.
-    var n2b[254];
-    n2b = Num2Bits_strict()(in[0] + (1<<n) - in[1]);
+    component n2b = Num2Bits(n + 1);
+    n2b.in <== in[0] + (1<<n) - in[1];
 
     // Determine if in[0] is less than in[1] based on the most significant bit.
-    out <== 1 - n2b[n];
+    out <== 1 - n2b.out[n];
 }
 
 // Template to check if one input is less than or equal to another.


### PR DESCRIPTION
re #15

<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description


<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

- Added range checks to ensure inputs are constrained to n bits using Num2Bits.
- Corrected the instantiation of Num2Bits to use n + 1 bits for handling potential overflow.
- Added comments to clarify the logic for determining if one input is less than another.

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

Closes #15 

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [ ] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
