### PR TITLE
fix: range check constrain in `float.circom`

### DIFF
--- a/packages/utils/src/float.circom
+++ b/packages/utils/src/float.circom
@@ -52,22 +52,18 @@ template IntegerDivision(n) {
     // Quotient.
     signal output c;
 
-    // Ensure inputs are within the valid range.
-    var lta;
-    var ltb;
-
-    lta = LessThan(252)([a, 2**n]);
-    ltb = LessThan(252)([b, 2**n]);
-
-    assert(lta == 1);
-    assert(ltb == 1);
+    // Constrain Dividend and Divisor to n bits.
+    component range_check[2];
+    for (var i = 0; i < 2; i++){ range_check[i] = Num2Bits(n);}
+    range_check[0].in <== a;
+    range_check[1].in <== b;
 
     // Ensure the divisor 'b' is not zero.
     var isz;
 
     isz = IsZero()(b);
 
-    assert(isz == 0);
+    isz === 0;
 
     // Prepare variables for division.
     var dividend = a;

--- a/packages/utils/src/float.circom
+++ b/packages/utils/src/float.circom
@@ -116,7 +116,7 @@ template ToFloat(W) {
 
     lt = LessEqThan(252)([in, 10 ** (75 - W)]);
 
-    assert(lt == 1);
+    lt === 1;
 
     // Convert the integer to floating-point by multiplying with 10^W.
     out <== in * (10**W);
@@ -141,7 +141,7 @@ template DivisionFromFloat(W, n) {
 
     lt = LessEqThan(252)([a, 10 ** (75 - W)]);
 
-    assert(lt == 1);
+    lt === 1;
 
     // Use IntegerDivision for division operation.
     c <== IntegerDivision(n)(a * (10 ** W), b);
@@ -177,14 +177,10 @@ template MultiplicationFromFloat(W, n) {
     signal output c;
 
     // Ensure both inputs 'a' and 'b' are within a valid range for multiplication.
-    var lta;
-    var ltb;
-
-    lta = LessEqThan(252)([a, 2 ** 126]);
-    ltb = LessEqThan(252)([b, 2 ** 126]);
-
-    assert(lta == 1);
-    assert(ltb == 1);
+    component range_check[2];
+    for (var i = 0; i < 2; i++){ range_check[i] = Num2Bits(126);}
+    range_check[0].in <== a;
+    range_check[1].in <== b;
 
     // Perform integer division after multiplication to adjust the result back to W decimal digits.
     c <== IntegerDivision(n)(a * b, 10 ** W);


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description
- Fixed the range check implementation of `IntegerDivision` and `MultiplicationFromFloat`
- Replaced ` assert(lt == 1)` with lt === 1 constrain
- Replaced ` assert(isz == 0)` with lsz === 0 constrain

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

## Related Issue(s)
#13 

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- Feel free to remove this section if you will not use it. -->

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [x] I have run `yarn style` without getting any errors
-   [ ] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept minor grammatical fixes (e.g., correcting typos, rewording sentences) unless they significantly improve clarity in technical documentation. These contributions, while appreciated, are not a priority for merging. If there is a grammatical mistake, please feel free to message the team.
