### PR TITLE
fix(binary-merkle-root)!: use num2bits circuit to enforce that indices are 0 or 1

### DIFF
--- a/packages/binary-merkle-root/src/binary-merkle-root.circom
+++ b/packages/binary-merkle-root/src/binary-merkle-root.circom
@@ -6,17 +6,22 @@ include "comparators.circom";
 
 // This circuit is designed to calculate the root of a binary Merkle
 // tree given a leaf, its depth, and the necessary sibling
-// information (aka proof of membership).
+// information (aka proof of membership) which includes the index (a decimal
+// value whose binary representation defines the path indices) 
+// and the sibling nodes. If the number of siblings equals the depth,
+// the index corresponds to the position of the leaf in the tree.
+//
 // A circuit is designed without the capability to iterate through
 // a dynamic array. To address this, a parameter with the static maximum
 // tree depth is defined (i.e. 'MAX_DEPTH'). And additionally, the circuit
 // receives a dynamic depth as an input, which is utilized in calculating the
 // true root of the Merkle tree. The actual depth of the Merkle tree
 // may be equal to or less than the static maximum depth.
+//
 // NOTE: This circuit will successfully verify `out = 0` for `depth > MAX_DEPTH`.
 // Make sure to enforce `depth <= MAX_DEPTH` outside the circuit.
 template BinaryMerkleRoot(MAX_DEPTH) {
-    signal input leaf, depth, indices[MAX_DEPTH], siblings[MAX_DEPTH];
+    signal input leaf, depth, index, siblings[MAX_DEPTH];
 
     signal output out;
 
@@ -26,6 +31,8 @@ template BinaryMerkleRoot(MAX_DEPTH) {
     signal roots[MAX_DEPTH];
     var root = 0;
 
+    signal indices[MAX_DEPTH] <== Num2Bits(MAX_DEPTH)(index);
+    
     for (var i = 0; i < MAX_DEPTH; i++) {
         var isDepth = IsEqual()([depth, i]);
 

--- a/packages/binary-merkle-root/tests/binary-merkle-root.test.ts
+++ b/packages/binary-merkle-root/tests/binary-merkle-root.test.ts
@@ -6,23 +6,6 @@ describe("binary-merkle-root", () => {
 
     const MAX_DEPTH = 5
 
-    it("Should throw an error if MAX_DEPTH is zero", async () => {
-        const INPUT = {
-            leaf: BigInt(0),
-            depth: BigInt(0),
-            index: 0,
-            siblings: []
-        }
-
-        circuit = await circomkit.WitnessTester("binary-merkle-root", {
-            file: "binary-merkle-root",
-            template: "BinaryMerkleRoot",
-            params: [MAX_DEPTH]
-        })
-
-        await circuit.expectFail(INPUT)
-    })
-
     it("Should throw an error if there are not enough values for input signal siblings", async () => {
         const INPUT = {
             leaf: BigInt(0),

--- a/packages/binary-merkle-root/tests/binary-merkle-root.test.ts
+++ b/packages/binary-merkle-root/tests/binary-merkle-root.test.ts
@@ -2,7 +2,7 @@ import { WitnessTester } from "circomkit"
 import { circomkit, generateBinaryMerkleRoot } from "./common"
 
 describe("binary-merkle-root", () => {
-    let circuit: WitnessTester<["leaf", "depth", "indices", "siblings"], ["out"]>
+    let circuit: WitnessTester<["leaf", "depth", "index", "siblings"], ["out"]>
 
     const MAX_DEPTH = 5
 
@@ -10,24 +10,7 @@ describe("binary-merkle-root", () => {
         const INPUT = {
             leaf: BigInt(0),
             depth: BigInt(0),
-            indices: [],
-            siblings: []
-        }
-
-        circuit = await circomkit.WitnessTester("binary-merkle-root", {
-            file: "binary-merkle-root",
-            template: "BinaryMerkleRoot",
-            params: [MAX_DEPTH]
-        })
-
-        await circuit.expectFail(INPUT)
-    })
-
-    it("Should throw an error if there are not enough values for input signal indices", async () => {
-        const INPUT = {
-            leaf: BigInt(0),
-            depth: MAX_DEPTH,
-            indices: [],
+            index: 0,
             siblings: []
         }
 
@@ -44,7 +27,7 @@ describe("binary-merkle-root", () => {
         const INPUT = {
             leaf: BigInt(0),
             depth: MAX_DEPTH,
-            indices: [BigInt(0), BigInt(0), BigInt(0), BigInt(0), BigInt(0)],
+            index: 0,
             siblings: []
         }
 
@@ -58,12 +41,12 @@ describe("binary-merkle-root", () => {
     })
 
     it("Should throw an error if there are too many values for input signal siblings", async () => {
-        const { leaf, depth, indices, siblings } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** MAX_DEPTH + 1)
+        const { leaf, depth, index, siblings } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** MAX_DEPTH + 1)
 
         const INPUT = {
             leaf,
             depth,
-            indices,
+            index,
             siblings
         }
 
@@ -77,12 +60,12 @@ describe("binary-merkle-root", () => {
     })
 
     it("Should throw an error if number of leafs is more than MAX_DEPTH", async () => {
-        const { leaf, depth, indices, siblings } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** MAX_DEPTH + 1)
+        const { leaf, depth, index, siblings } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** MAX_DEPTH + 1)
 
         const INPUT = {
             leaf,
             depth,
-            indices,
+            index,
             siblings
         }
 
@@ -96,12 +79,12 @@ describe("binary-merkle-root", () => {
     })
 
     it("Should calculate the root correctly if the depth is less than MAX_DEPTH", async () => {
-        const { leaf, depth, indices, siblings, root } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** (MAX_DEPTH - 2))
+        const { leaf, depth, index, siblings, root } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** (MAX_DEPTH - 2))
 
         const INPUT = {
             leaf,
             depth,
-            indices,
+            index,
             siblings
         }
 
@@ -119,12 +102,12 @@ describe("binary-merkle-root", () => {
     })
 
     it("Should calculate the root correctly if the depth equals MAX_DEPTH", async () => {
-        const { leaf, depth, indices, siblings, root } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** MAX_DEPTH)
+        const { leaf, depth, index, siblings, root } = generateBinaryMerkleRoot(MAX_DEPTH, 2 ** MAX_DEPTH)
 
         const INPUT = {
             leaf,
             depth,
-            indices,
+            index,
             siblings
         }
 

--- a/packages/binary-merkle-root/tests/common.ts
+++ b/packages/binary-merkle-root/tests/common.ts
@@ -19,14 +19,14 @@ export const circomkit = new Circomkit({
  *
  * @typeParam leaf the leaf value.
  * @typeParam depth the actual depth of the Merkle tree.
- * @typeParam indices binary representation of the `leafIndex` path.
+ * @typeParam index the leaf index.
  * @typeParam siblings nodes encountered when traversing from the leaf to the root.
  * @typeParam root the Merkle root of the tree, calculated from all the leaves.
  */
 export type BinaryMerkleTreeProof = {
     leaf: bigint
     depth: number
-    indices: number[]
+    index: number
     siblings: bigint[]
     root: bigint
 }
@@ -56,15 +56,11 @@ export const generateBinaryMerkleRoot = (maxDepth = 5, nodes = 32, leafIndex = 0
 
     const depth = siblings.length
 
-    // The index must be converted to a list of indices, 1 for each tree level.
-    // The circuit tree depth is 20, so the number of siblings must be 20, even if
-    // the tree depth is actually 3. The missing siblings can be set to 0, as they
-    // won't be used to calculate the root in the circuit.
-    const indices: number[] = []
-
+    // For example, if the circuit expects a Merkle tree of depth 20,
+    // the input must always include 20 sibling nodes, even if the actual
+    // tree depth is smaller (e.g., 3). The unused sibling positions can be
+    // filled with 0, as they won't affect the root calculation in the circuit.
     for (let i = 0; i < maxDepth; i += 1) {
-        indices.push((index >> i) & 1)
-
         if (siblings[i] === undefined) {
             siblings[i] = BigInt(0)
         }
@@ -73,7 +69,7 @@ export const generateBinaryMerkleRoot = (maxDepth = 5, nodes = 32, leafIndex = 0
     return {
         leaf,
         depth,
-        indices,
+        index,
         siblings,
         root: tree.root
     }


### PR DESCRIPTION
<!-- Please refer to our CONTRIBUTING documentation for any questions on submitting a pull request. -->
<!-- Provide a general summary of your changes in the Title above. -->

## Description

<!-- Describe your changes in detail. -->
<!-- You may want to answer some of the following questions: -->
<!-- What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...) -->
<!-- What is the current behavior?** (You can also link to an open issue here) -->
<!-- What is the new behavior (if this is a feature change)? -->
<!-- Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?) -->

The changes in the BinaryMerkleRoot are:
1. Replaced `indices[MAX_DEPTH]` with `index`.
Instead of passing an array of indices representing the path in the Merkle tree, the circuit now takes a single index input. This index is a decimal value whose binary representation defines the path indices.
2. New line before the for loop: `signal indices[MAX_DEPTH] <== Num2Bits(MAX_DEPTH)(index);`
This line converts the index value into its binary representation.

**Note**: The `index` does not always correspond to the leaf's position in the tree (e.g., when using the LeanIMT). However, if the number of siblings equals the tree's depth, then the index matches the leaf's position.

## Additional Info

As part of the fix, we also considered adding the line `indices[i] * (1 - indices[i]) === 0;` inside the for loop to ensure all indices are either 0 or 1. However, we ultimately decided to use the `Num2Bits` circuit instead, for the following reasons:

- It results in the same number of constraints.
- Projects like [Privacy Pools](https://github.com/0xbow-io/privacy-pools-core/blob/main/packages/circuits/circuits/merkleTree.circom#L49-L52) and [POD](https://github.com/proofcarryingdata/zupass/blob/main/packages/lib/gpcircuits/circuits/entry.circom#L38) also use `Num2Bits` for this purpose.
- It aligns better with the LeanIMT Merkle proof structure.
- It remains compatible with general binary Merkle trees.
- When using LeanIMT, proof generation is slightly more performant, since there's no longer a need to manually construct the path indices array: https://github.com/semaphore-protocol/semaphore/blob/v4.11.1/packages/proof/src/generate-proof.ts#L99

## Related Issue(s)

<!-- This project accepts pull requests related to open issues. -->
<!-- If suggesting a new feature or change, please discuss it in an issue first. -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce. -->
<!-- Please link to the issue(s) here -->

<!-- Closes # -->
<!-- Fixes # -->

Closes #24 

## Checklist

<!-- Please check if the PR fulfills these requirements. -->

-   [x] I have read and understand the [contributor guidelines](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/privacy-scaling-explorations/zk-kit.circom/blob/main/CODE_OF_CONDUCT.md).
-   [x] I have performed a self-review of my code
-   [x] I have commented my code, particularly in hard-to-understand areas
-   [x] My changes generate no new warnings
-   [ ] I have run `yarn style` without getting any errors
-   [x] I have added tests that prove my fix is effective or that my feature works
-   [x] New and existing unit tests pass locally with my changes

> [!IMPORTANT]
> We do not accept pull requests for minor grammatical fixes (e.g., correcting typos, rewording sentences) or for fixing broken links, unless they significantly improve clarity or functionality. These contributions, while appreciated, are not a priority for merging. If you notice any of these issues, please create a [GitHub Issue](https://github.com/privacy-scaling-explorations/zk-kit.circom/issues/new?template=BLANK_ISSUE) to report them so they can be properly tracked and addressed.
